### PR TITLE
fix alf box building - don't use gcc

### DIFF
--- a/afl-dockerfile
+++ b/afl-dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work
-ARG CC=gcc
-ARG CXX=g++
+#ARG CC=gcc
+#ARG CXX=g++
 ARG LLVM_CONFIG=llvm-config
 RUN git clone https://github.com/vanhauser-thc/AFLplusplus
 RUN cd AFLplusplus && make clean -j4 && make distrib -j4 && \


### PR DESCRIPTION
I have problem with building afl docker image with this docker file until gcc ENV tip about desired compilers (CC; CXX) for make was commented out.

Is that issue we want to face or I missing some milestone out threre?

Thanks and kudos for @fumfel ;D